### PR TITLE
Improve the JS package api and size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,12 @@ coverage
 doc
 oakdex-pokedex.gemspec
 schemas_to_markdown.js
+data/ability/
+data/egg_group/
+data/generation/
+data/move/
+data/nature/
+data/pokemon/
+data/region/
+data/schemas/
+data/type/

--- a/README.md
+++ b/README.md
@@ -86,66 +86,52 @@ Then you can use the library:
 ```js
 oakdexPokedex = require('oakdex-pokedex');
 
-oakdexPokedex.findPokemon('Eevee', function(p) {
-  // returns data/pokemon/eevee.json
-  console.log(p.names.en); // Eeevee
-});
+const eevee = oakdexPokedex.findPokemon('Eevee')
+// returns data/pokemon/eevee.json
+console.log(eevee.names.en); // Eeevee
 
-oakdexPokedex.findPokemon(4, function(p) {
-  // returns data/pokemon/charmander.json
-  console.log(p.names.en); // Charmander
-});
+const charmander = oakdexPokedex.findPokemon(4)
+// returns data/pokemon/charmander.json
+console.log(charmander.names.en); // Charmander
 
-oakdexPokedex.findMove('Tackle', function(m) {
-  // returns data/move/tackle.json
-  console.log(m.names.en); // Tackle
-});
+const tackle = oakdexPokedex.findMove('Tackle')
+// returns data/move/tackle.json
+console.log(m.names.en); // Tackle
 
-oakdexPokedex.findAbility('Contrary', function(a) {
-  // returns data/ability/contrary.json
-  console.log(a.names.en); // Contrary
-});
+const contrary = oakdexPokedex.findAbility('Contrary')
+// returns data/ability/contrary.json
+console.log(a.names.en); // Contrary
 
-oakdexPokedex.findType('Fairy', function(t) {
-  // returns data/type/fairy.json
-  console.log(t.names.en); // Fairy
-});
+const fairy = oakdexPokedex.findType('Fairy')
+// returns data/type/fairy.json
+console.log(fairy.names.en); // Fairy
 
-oakdexPokedex.findEggGroup('Water 1', function(e) {
-  // returns data/egg_group/water_1.json
-  console.log(e.names.en); // Water 1
-});
+const water1 = oakdexPokedex.findEggGroup('Water 1')
+// returns data/egg_group/water_1.json
+console.log(water1.names.en); // Water 1
 
-oakdexPokedex.findGeneration('Generation VI', function(g) {
-  // returns data/generation/6.json
-  console.log(g.names.en); // Generation VI
-});
+const genVI = oakdexPokedex.findGeneration('Generation VI')
+// returns data/generation/6.json
+console.log(genVI.names.en); // Generation VI
 
-oakdexPokedex.findNature('Bold', function(n) {
-  // returns data/nature/bold.json
-  console.log(n.names.en); // Bold
-});
+const bold = oakdexPokedex.findNature('Bold')
+// returns data/nature/bold.json
+console.log(bold.names.en); // Bold
 
+const allPokemon = oakdexPokedex.allPokemon()
+console.log(allPokemon.length); // 802
 
-oakdexPokedex.allPokemon(function(pokemon) {
-  console.log(pokemon.length); // 802
-});
+const darkPokemon = oakdexPokedex.allPokemon({ type: 'Dark' })
+console.log(darkPokemon.length); // 46
 
-oakdexPokedex.allPokemon({ type: 'Dark' }, function(pokemon) {
-  console.log(pokemon.length); // 46
-});
+const humanLike = oakdexPokedex.allPokemon({ egg_group: 'Human-Like' })
+console.log(humanLike.length); // 52
 
-oakdexPokedex.allPokemon({ egg_group: 'Human-Like' }, function(pokemon) {
-  console.log(pokemon.length); // 52
-});
+const alola = oakdexPokedex.allPokemon({ dex: 'alola' })
+console.log(alola.length); // 302
 
-oakdexPokedex.allPokemon({ dex: 'alola' }, function(pokemon) {
-  console.log(pokemon.length); // 302
-});
-
-oakdexPokedex.allMoves({ type: 'Ground' }, function(moves) {
-  console.log(moves.length); // 26
-});
+const moves = oakdexPokedex.allMoves({ type: 'Ground' })
+console.log(moves.length); // 26
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "mocha": "^5.2.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --bail"
   },
   "repository": {
     "type": "git",

--- a/test/test-oakdex-pokedex.js
+++ b/test/test-oakdex-pokedex.js
@@ -1,296 +1,261 @@
-var oakdexPokedex = require('../src/oakdex_pokedex');
-var expect = require('expect.js');
-var fs = require('fs');
+'use strict';
+const oakdexPokedex = require('../src/oakdex_pokedex');
+const expect = require('expect.js');
+const fs = require('fs');
 
 describe('OakdexPokedex', function() {
   describe('#findPokemon', function() {
     it('finds eevee by name', function(done) {
-      oakdexPokedex.findPokemon('Eevee', function(pkmn) {
-        fs.readFile('./data/pokemon/eevee.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(pkmn.names.de).to.equal('Evoli');
-          expect(pkmn).to.eql(obj);
-          done();
-        });
+      const pkmn = oakdexPokedex.findPokemon('Eevee')
+      fs.readFile('./data/pokemon/eevee.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(pkmn.names.de).to.equal('Evoli');
+        expect(pkmn).to.eql(obj);
+        done();
       });
     });
 
     it('finds charmander by id', function(done) {
-      oakdexPokedex.findPokemon(4, function(pkmn) {
-        fs.readFile('./data/pokemon/charmander.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(pkmn.names.de).to.equal('Glumanda');
-          expect(pkmn).to.eql(obj);
-          done();
-        });
+      const pkmn = oakdexPokedex.findPokemon(4)
+      fs.readFile('./data/pokemon/charmander.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(pkmn.names.de).to.equal('Glumanda');
+        expect(pkmn).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if pokemon does not exist', function(done) {
-      oakdexPokedex.findPokemon('NotKnownByMe', function(pkmn) {
-        expect(pkmn).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findPokemon('NotKnownByMe')).to.equal(null);
+      done()
     });
   });
 
   describe('#findMove', function() {
     it('finds Tackle by name', function(done) {
-      oakdexPokedex.findMove('Tackle', function(found) {
-        fs.readFile('./data/move/tackle.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findMove('Tackle')
+      fs.readFile('./data/move/tackle.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findMove('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findMove('NotKnownByMe')).to.equal(null);
+      done();
     });
   });
 
   describe('#findAbility', function() {
     it('finds Contrary by name', function(done) {
-      oakdexPokedex.findAbility('Contrary', function(found) {
-        fs.readFile('./data/ability/contrary.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findAbility('Contrary')
+      fs.readFile('./data/ability/contrary.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findAbility('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findAbility('NotKnownByMe')).to.equal(null);
+      done();
     });
   });
 
   describe('#findType', function() {
     it('finds Fairy by name', function(done) {
-      oakdexPokedex.findType('Fairy', function(found) {
-        fs.readFile('./data/type/fairy.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findType('Fairy')
+      fs.readFile('./data/type/fairy.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findType('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findType('NotKnownByMe')).to.equal(null);
+      done();
     });
   });
 
   describe('#findRegion', function() {
     it('finds Region by name', function(done) {
-      oakdexPokedex.findRegion('Kanto', function(found) {
-        fs.readFile('./data/region/kanto.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findRegion('Kanto')
+      fs.readFile('./data/region/kanto.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findRegion('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findRegion('NotKnownByMe')).to.equal(null);
+      done();
     });
   });
 
   describe('#findEggGroup', function() {
     it('finds Water 1 by name', function(done) {
-      oakdexPokedex.findEggGroup('Water 1', function(found) {
-        fs.readFile('./data/egg_group/water_1.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findEggGroup('Water 1')
+      fs.readFile('./data/egg_group/water_1.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findEggGroup('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findEggGroup('NotKnownByMe')).to.equal(null);
+      done();
     });
   });
 
   describe('#findGeneration', function() {
     it('finds Generation VI by name', function(done) {
-      oakdexPokedex.findGeneration('Generation VI', function(found) {
-        fs.readFile('./data/generation/6.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findGeneration('Generation VI')
+      fs.readFile('./data/generation/6.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findGeneration('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      const found = oakdexPokedex.findGeneration('NotKnownByMe')
+      expect(found).to.equal(null);
+      done();
     });
   });
 
   describe('#findNature', function() {
     it('finds Bold by name', function(done) {
-      oakdexPokedex.findNature('Bold', function(found) {
-        fs.readFile('./data/nature/bold.json', 'utf8', function (err, data) {
-          if(err) {
-            throw err;
-          }
-          var obj = JSON.parse(data);
-          expect(found).to.eql(obj);
-          done();
-        });
+      const found = oakdexPokedex.findNature('Bold')
+      fs.readFile('./data/nature/bold.json', 'utf8', function (err, data) {
+        if(err) {
+          throw err;
+        }
+        const obj = JSON.parse(data);
+        expect(found).to.eql(obj);
+        done();
       });
     });
 
     it('returns null if entry does not exist', function(done) {
-      oakdexPokedex.findNature('NotKnownByMe', function(found) {
-        expect(found).to.equal(null);
-        done();
-      });
+      expect(oakdexPokedex.findNature('NotKnownByMe')).to.equal(null);
+      done();
     });
   });
 
   describe('#allPokemon', function() {
     it('finds all pokemon', function(done) {
-      oakdexPokedex.allPokemon(function(list) {
-        expect(list.length).to.equal(807);
-        done();
-      });
+      const list = oakdexPokedex.allPokemon()
+      expect(list.length).to.equal(807);
+      done();
     });
 
     it('finds Dark pokemon', function(done) {
-      oakdexPokedex.allPokemon({ type: 'Dark' }, function(list) {
-        expect(list.length).to.equal(46);
-        done();
-      });
+      const list = oakdexPokedex.allPokemon({ type: 'Dark' })
+      expect(list.length).to.equal(46);
+      done();
     });
 
     it('finds Human-Like pokemon', function(done) {
-      oakdexPokedex.allPokemon({ egg_group: 'Human-Like' }, function(list) {
-        expect(list.length).to.equal(52);
-        done();
-      });
+      const list = oakdexPokedex.allPokemon({ egg_group: 'Human-Like' })
+      expect(list.length).to.equal(52);
+      done();
     });
 
     it('finds by alola id', function(done) {
-      oakdexPokedex.allPokemon({ dex: 'alola' }, function(list) {
-        expect(list.length).to.equal(302);
-        done();
-      });
+      const list = oakdexPokedex.allPokemon({ dex: 'alola' })
+      expect(list.length).to.equal(302);
+      done();
     });
   });
 
   describe('#allMoves', function() {
     it('finds all moves', function(done) {
-      oakdexPokedex.allMoves(function(list) {
-        expect(list.length).to.equal(710);
-        done();
-      });
+      const list = oakdexPokedex.allMoves()
+      expect(list.length).to.equal(710);
+      done();
     });
 
     it('finds Ground moves', function(done) {
-      oakdexPokedex.allMoves({ type: 'Ground' }, function(list) {
-        expect(list.length).to.equal(26);
-        done();
-      });
+      const list = oakdexPokedex.allMoves({ type: 'Ground' })
+      expect(list.length).to.equal(26);
+      done();
     });
   });
 
   describe('#allAbilities', function() {
     it('finds all abilities', function(done) {
-      oakdexPokedex.allAbilities(function(list) {
-        expect(list.length).to.equal(232);
-        done();
-      });
+      const list = oakdexPokedex.allAbilities()
+      expect(list.length).to.equal(232);
+      done();
     });
   });
 
   describe('#allTypes', function() {
     it('finds all types', function(done) {
-      oakdexPokedex.allTypes(function(list) {
-        expect(list.length).to.equal(18);
-        done();
-      });
+      const list = oakdexPokedex.allTypes()
+      expect(list.length).to.equal(18);
+      done();
     });
   });
 
   describe('#allRegions', function() {
     it('finds all regions', function(done) {
-      oakdexPokedex.allRegions(function(list) {
-        expect(list.length).to.equal(7);
-        done();
-      });
+      const list = oakdexPokedex.allRegions()
+      expect(list.length).to.equal(7);
+      done();
     });
   });
 
   describe('#allEggGroups', function() {
     it('finds all egg groups', function(done) {
-      oakdexPokedex.allEggGroups(function(list) {
-        expect(list.length).to.equal(15);
-        done();
-      });
+      const list = oakdexPokedex.allEggGroups()
+      expect(list.length).to.equal(15);
+      done();
     });
   });
 
   describe('#allGenerations', function() {
     it('finds all generations', function(done) {
-      oakdexPokedex.allGenerations(function(list) {
-        expect(list.length).to.equal(7);
-        done();
-      });
+      const list = oakdexPokedex.allGenerations()
+      expect(list.length).to.equal(7);
+      done();
     });
   });
 
   describe('#allNatures', function() {
     it('finds all natures', function(done) {
-      oakdexPokedex.allNatures(function(list) {
-        expect(list.length).to.equal(25);
-        done();
-      });
+      const list = oakdexPokedex.allNatures()
+      expect(list.length).to.equal(25);
+      done();
     });
   });
 });


### PR DESCRIPTION
Change from callback functions to sync functions loading all needed data during module initialization time and removing a race condition if a function was called twice while the file was loading. The interface is now more simple.

Filtering is also a lot more performant and can't accidentally return a pokemon twice if two filters match.

Dynamically reading the json when asked doesn't work outside of nodejs. This module can now be webpacked and used anywhere (browsers, lambda, robots, etc).

We no longer ship files that aren't used reducing the package size by about half. (69 MB to 23MB)